### PR TITLE
Fix premiere dates

### DIFF
--- a/xml/BOISSY_BABILLARD.xml
+++ b/xml/BOISSY_BABILLARD.xml
@@ -50,7 +50,7 @@
 				<printer id='LE BRETON'></printer>
 			</docImprint>
 		<performance>
-		<premiere date='1745-03618' location='Théâtre de la rue des Fossés Saint-Germain'>Représentée, pour la première fois, en 1725.</premiere>
+		<premiere date='1725' location='Théâtre de la rue des Fossés Saint-Germain'>Représentée, pour la première fois, en 1725.</premiere>
 		</performance>
 		<div type="preface"><head>PRESENTATION</head>
 		<p>Voici une petite comédie de 520 vers n'est pas la plus représentative du classisisme masi son intérêt est triple. Le sujet est originale, les lieux, spectacles et auteurs cités sont une utile présentation sur ce que était la vie culturelle au XVIIème sicècle. </p>

--- a/xml/CORNEILLET_TIMOCRATE.xml
+++ b/xml/CORNEILLET_TIMOCRATE.xml
@@ -41,7 +41,7 @@
 			<printer id="***">Suivant la copie imprimée à Paris.</printer>
 		</docImprint>
 		<performance>
-			<premiere date="1656-11-" location='Théâtre du Marais'>Représenté pour la première fois en novembre 1656 au Théâtre de l'Hôtel du Marais et reprise ensuite avec un moindre succès à l'Hôtel de Bourgogne.</premiere>
+			<premiere date="1656-11" location='Théâtre du Marais'>Représenté pour la première fois en novembre 1656 au Théâtre de l'Hôtel du Marais et reprise ensuite avec un moindre succès à l'Hôtel de Bourgogne.</premiere>
 		</performance>
 	<div type="dedicace"><adresse>À MONSEIGNEUR, MONSEIGNEUR LE DUC DE GUISE.</adresse>
 		<head>MONSEIGNEUR,</head>

--- a/xml/DANCOURT_SANCHO.xml
+++ b/xml/DANCOURT_SANCHO.xml
@@ -34,7 +34,7 @@
 		</docImprint>
 		<printer id='GUILLAIN'>À PARIS, chez Thomas GUILLLAIN, proche les Augustins, à la descente du Pont-Neuf, à l'image Saint Louis.</printer>
 		<performance>
-			<premiere date='1712-11-' location='Théâtre de la rue des Fossés Saint-Germain'>Représentée pour la première fois, au mois de Novembre 1712 au Théâtre de la rue des Fossés Saint-Germain.</premiere>
+			<premiere date='1712-11' location='Théâtre de la rue des Fossés Saint-Germain'>Représentée pour la première fois, au mois de Novembre 1712 au Théâtre de la rue des Fossés Saint-Germain.</premiere>
 		</performance>
 <div type="dedicace"><adresse>À MONSEIGNEUR LE DUC DE MORTEMART. Pair de France, PREMIER GENTILHOMME DE LA CHAMBRE DU ROI. </adresse>
 	<p type="v">Dans l'espoir que quelques ouvrages </p>

--- a/xml/FEYDEAU_NOTREFUTUR.xml
+++ b/xml/FEYDEAU_NOTREFUTUR.xml
@@ -34,7 +34,8 @@
 			<acheveImprime id=''></acheveImprime>
 			<editor id='OLLENDORF'>PARIS, PAUL OLLENDORFF, ÉDITEUR, 28 bis, RUE DE RICHELIEU.</editor>		
 		</docImprint>
-	<premiere>Représentée pour la première fois, à Paris, à la salle de géographie, le 11 février 1894.</premiere>
+	<!-- FIXME: this is the same premiere date as in HERVILLY_LAITIERE.xml -->
+	<premiere date="1894-02-11">Représentée pour la première fois, à Paris, à la salle de géographie, le 11 février 1894.</premiere>
 	<castList><head>PERSONNAGES</head>
 		<castItem><role id="HENRIETTE DE TRÉVILLE" sex="2" type="H" statut='aristocrate' age='A' stat_amour='néant'>HENRIETTE DE TRÉVILLE</role>.</castItem> 
 		<castItem><role id="VALENTINE" sex="2" type="H" statut='aristocrate' age='A' stat_amour='néant'>VALENTINE</role>.</castItem> 

--- a/xml/GRANDVAL_EUNUQUE.xml
+++ b/xml/GRANDVAL_EUNUQUE.xml
@@ -38,7 +38,7 @@
 	<acheveImprime id=""></acheveImprime>
 		</docImprint>
 		<performance>
-			<premiere date="10-1755" location='Charlotte de Montmartre'></premiere>
+			<premiere date="1755-10" location='Charlotte de Montmartre'></premiere>
 		</performance>
 		<div type="dedicace"><head>ÉPITRE DEDICATOIRE.</head>
 			<adresse>L'AUTEUR À SES AMIS.</adresse>

--- a/xml/GRANDVAL_LUXURIEUX.xml
+++ b/xml/GRANDVAL_LUXURIEUX.xml
@@ -40,7 +40,7 @@
 	<acheveImprime id=""></acheveImprime>
 		</docImprint>
 		<performance>
-			<premiere date="10-1755" location='Charlotte de Montmartre'></premiere>
+			<premiere date="1755-10" location='Charlotte de Montmartre'></premiere>
 		</performance>
 	<castList><head>ACTEURS</head>
 		<castItem><role id="VALÈRE" sex="1" type="H" statut='bourgeois' age='A' stat_amour='néant'>VALÈRE</role>, Luxurieux.</castItem>

--- a/xml/GRANDVAL_TEMPERAMENT.xml
+++ b/xml/GRANDVAL_TEMPERAMENT.xml
@@ -39,7 +39,7 @@
 	<acheveImprime id=""></acheveImprime>
 		</docImprint>
 		<performance>
-			<premiere date="10-1755" location='Charlotte de Montmartre'></premiere>
+			<premiere date="1755-10" location='Charlotte de Montmartre'></premiere>
 		</performance>
 	<castList><head>ACTEURS</head>
 		<castItem><role id="IMPIAS" sex="1" type="H" statut='prêtre' age='A' stat_amour='néant'>IMPIAS</role>.</castItem>

--- a/xml/HERVILLY_LAITIERE.xml
+++ b/xml/HERVILLY_LAITIERE.xml
@@ -34,7 +34,8 @@
 			<acheveImprime id=''></acheveImprime>
 			<editor id='OLLENDORF'>PARIS, PAUL OLLENDORFF, ÉDITEUR, 28 bis, RUE DE RICHELIEU.</editor>		
 		</docImprint>
-	<premiere>Représentée pour la première fois, à Paris, à la salle de géographie, le 11 février 1894.</premiere>
+	<!-- FIXME: this is the same premiere date as in FEYDEAU_NOTREFUTUR.xml -->
+	<premiere date="1894-02-11">Représentée pour la première fois, à Paris, à la salle de géographie, le 11 février 1894.</premiere>
 	<castList><head>PERSONNAGES</head>
 		<castItem><role id="MAURICE HAMELIN" sex="1" type="H" statut='bourgeois' age='A' stat_amour='néant'>MAURICE HAMELIN</role>.</castItem> 
 		<castItem><role id="GEORGES DE BRACY" sex="1" type="H" statut='aristocrate' age='A' stat_amour='néant'>GEORGES DE BRACY</role>.</castItem> 

--- a/xml/LESENNE_REVEILCORNEILLE.xml
+++ b/xml/LESENNE_REVEILCORNEILLE.xml
@@ -36,7 +36,7 @@
 			<editor value='EDITION ET LIBRAIRIE'>PARIS, ÉDITIONS ET LIBRAIRIE, 40, rue de Seine, 40. </editor>
 			<printer value='ARRAULT'>TOURS, Imprimerie E. ARRAULT et Cie. </printer>
 		</docImprint>
-		<premiere>Représenté pour la première fois sur la scène de l'École des Hautes Études Sociales, le 8 Mai 1916, pour le 310e Anniversaire de Pierre Corneille.</premiere>
+		<premiere date="1916-05-08">Représenté pour la première fois sur la scène de l'École des Hautes Études Sociales, le 8 Mai 1916, pour le 310e Anniversaire de Pierre Corneille.</premiere>
 	<div type=""><head>DU MÊME AUTEUR</head>
 		<p>ROMANS</p>
 			<p>En Commandite, - Louise Mengal, - Le Vertige, - La Dame du Lac, Delburq et C°, - La Fin d'une Race, - Les Idées du Docteur Simpson, L'Inconnue, - Lady Caroline, — Madame Ferraris, Madame Frusquin, - Mademoisellede Bagnols, - Le Mariage de Rosette, Les Mémoires de Cendrillon (ouvr. couronné par l'Académie Française), Monsieur Candaule, — Prégalas, - Le Testament de Lucy, - Train rapide, (BIBLIOTHÈQUE CALMANN-LÉVY). Vera Nicole (BIBLIOTHÈQUE CHARPENTIER). Cher Maître, - Chaîne mystique (BIBLIOTHÈQUE LE SOUDIER).</p>

--- a/xml/NORMAND_CLAQUEURS.xml
+++ b/xml/NORMAND_CLAQUEURS.xml
@@ -34,7 +34,8 @@
 			<acheveImprime id=''></acheveImprime>
 			<editor id='OLLENDORF'>PARIS, PAUL OLLENDORFF, ÉDITEUR, 28 bis, RUE DE RICHELIEU.</editor>		
 		</docImprint>
-	<premiere>Représentée pour la première fois, à Paris, à la salle de géographie, le 11 février 1894.</premiere>
+	<!-- FIXME: see HERVILLY_LAITIERE.xml and FEYDEAU_NOTREFUTUR.xml -->
+	<premiere date="1894-02-11">Représentée pour la première fois, à Paris, à la salle de géographie, le 11 février 1894.</premiere>
 	<castList><head>PERSONNAGES</head>
 		<castItem><role id="DUBATTOIR" sex="1" type="H" statut='bourgeois' age='A' stat_amour='néant'>DUBATTOIR</role>, COQUELIN aîné.</castItem> 
 		<castItem><role id="GALUCHAT" sex="1" type="H" statut='bourgeois' age='A' stat_amour='néant'>GALUCHAT</role>, COQUELIN cadet.</castItem> 

--- a/xml/PONSART_MOLIEREAVIENNE.xml
+++ b/xml/PONSART_MOLIEREAVIENNE.xml
@@ -34,7 +34,7 @@
 			<printer id='CALMANN LEVY'>PARIS, CALMANN LEVY, ÉDITEUR, ANCIENNE MASION MICHEL LEVY FRÈRE, RUE AUBER, 3, et BOULEVARD DES ITALIENS, 15 À LA LIBRAIRIE NOUVELLE.</printer>
 		</docImprint>
 		<performance>
-			<premiere>Représentée pour la première fois à Vienne le 9 octobre 1851, selon la préface de l'édition des oeuvres complète de Ponsard.</premiere>
+			<premiere date="1851-10-09">Représentée pour la première fois à Vienne le 9 octobre 1851, selon la préface de l'édition des oeuvres complète de Ponsard.</premiere>
 		</performance>
 	<div type="preface"><head>MOLIÈRE À VIENNE.</head>
 		<p>En sortant de Vienne au Nord, on suit un chemin bordé tour à tour de murs, de pierres sèches et de haies de buis. Par-dessus les murs et les haies, le regard découvre des jardins, des prés plantés d'arbres pareils à des vergers, des fermes blanchies à la chaux, aux toits de tuiles rouges. On monte une côte ; on s'arrête devant une maison isolée.</p>

--- a/xml/SAND_ROIATTEND.xml
+++ b/xml/SAND_ROIATTEND.xml
@@ -37,7 +37,7 @@
 			<printer id='TY'>POISSY. - TY, ET STÉR. DE AUG. BOURET.</printer>
 		</docImprint>
 		<performance>
-			<premiere date='1848-04-1848' location='Théâtre de la République'>Théâtre de la République, - 9 avril 1848</premiere>
+			<premiere date='1848-04-09' location='Théâtre de la République'>Théâtre de la République, - 9 avril 1848</premiere>
 		</performance>
 
 	<castList><head>DISTRIBUTION.</head>

--- a/xml/VIGE_OTHELLO.xml
+++ b/xml/VIGE_OTHELLO.xml
@@ -32,7 +32,7 @@
 		<docImprint>
 			<printer id='BONNE'>CHAMBERY. IMPRIMERIE BONNE, CONTE-GRAND. ET Cie.</printer>
 		</docImprint>
-	<premiere>Ce monologue a été joué sur le théâtre impérial de Chambéry, le jeudi 7 mars 1807, par M. B**** [illisible] jeune premier rôle de MM. Roger et Derville.</premiere>
+	<premiere date="1807-03-07">Ce monologue a été joué sur le théâtre impérial de Chambéry, le jeudi 7 mars 1807, par M. B**** [illisible] jeune premier rôle de MM. Roger et Derville.</premiere>
 	<div type="dedicace"><adresse>À M. ANDRÉ BARBAN.</adresse>
 		<p>Gaudes caminibus ; carmina personnus</p>
 		<p>	Donare, et pretiun dicere muneri</p>


### PR DESCRIPTION
This fixes missing or misspelled `date` attributes in `premiere` elements.

